### PR TITLE
Moving to Apple's supported dependencies only

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "SwiftCLI",
-        "repositoryURL": "https://github.com/jakeheis/SwiftCLI",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "2816678bcc37f4833d32abeddbdf5e757fa891d8",
-          "version": "6.0.2"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
+        }
+      },
+      {
+        "package": "swift-tools-support-core",
+        "repositoryURL": "https://github.com/apple/swift-tools-support-core",
+        "state": {
+          "branch": null,
+          "revision": "243beea77d20db46647a3de4765c96e2c801c7c7",
+          "version": "0.1.12"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,13 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/jakeheis/SwiftCLI", from: "6.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
+        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.1.12")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "Pomodoro", dependencies: ["SwiftCLI"]),
+        .target(name: "Pomodoro", dependencies: ["ArgumentParser", "SwiftToolsSupport"]),
         .target(name: "PomodoroCLI", dependencies: ["Pomodoro"]),
         .testTarget(name: "PomodoroTests", dependencies: ["Pomodoro"]),
     ]

--- a/Sources/PomodoroCLI/main.swift
+++ b/Sources/PomodoroCLI/main.swift
@@ -1,29 +1,27 @@
+import ArgumentParser
 import Foundation
 import Pomodoro
-import SwiftCLI
+import TSCBasic
 
-let durationDefault: String = "25m"
+struct PomodoroCLI: ParsableCommand {
+    @Option(help: "The duration of the pomodoro in seconds (100) or in minutes (10m)")
+    var duration: String = "25m"
 
-class PomodoroCommand: Command {
-    let name = "pomodoro-cli"
-    let shortDescription = "CLI pomodoro"
-
-    @Key("-d", "--duration", description: "The duration of the pomodoro in seconds (100) or in minutes (10m) (default to \(durationDefault))")
-    var duration: String?
-
-    @Key("-m", "--message", description: "The intent of the pomodoro (example: email zero)")
+    @Option(help: "The intent of the pomodoro (example: email zero)")
     var message: String?
 
-    func execute() throws {
+    func run() throws {
         do {
             var pomodoroMessage: String? = message
+
             if pomodoroMessage == nil {
-                pomodoroMessage = Input.readLine(
-                    prompt: "\u{001B}[32m💁‍♀️ What’s the intent of this pomodoro?\u{001B}[m\n"
-                )
+                let terminalController = TerminalController(stream: stdoutStream)
+                terminalController?.write("💁‍♀️ What is the intent of this pomodoro?", inColor: .green)
+                terminalController?.endLine()
+                pomodoroMessage = readLine()
             }
 
-            let durationAsTimeInterval = try TimeInterval.fromHumanReadableString(duration ?? durationDefault)
+            let durationAsTimeInterval = try TimeInterval.fromHumanReadableString(duration)
 
             let pomodoro = PomodoroDescription(duration: durationAsTimeInterval, message: pomodoroMessage)
             TimerViewCLI(output: FileHandle.standardOutput).start(pomodoro: pomodoro)
@@ -33,5 +31,4 @@ class PomodoroCommand: Command {
     }
 }
 
-let cli = CLI(singleCommand: PomodoroCommand())
-cli.goAndExit()
+PomodoroCLI.main()


### PR DESCRIPTION
When this project started in 2017, I used [Commander](https://github.com/kylef/Commander) and then switched to [SwiftCLI](https://github.com/jakeheis/SwiftCLI) at the beginning of 2020 to parse arguments and provide a help page.

A little later, in late February 2020, Apple released [Swift Argument Parser](https://github.com/apple/swift-argument-parser).

And then I stumbled upon [this article](https://www.fivestars.blog/code/ultimate-guide-swift-executables.html) that made me discover [Swift Tools Support Core](https://github.com/apple/swift-tools-support-core).

So today, I am taking advantage that PSG - Manchester United is not that exciting to move this code base's dependencies to packages that should become the *de-facto* standard for writing executable programs in Swift.