### PR TITLE
Fix dyld: Library not loaded: @rpath/libSwiftToolsSupport.dylib error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ docs:
 	./scripts/generateDocs.sh
 
 clean:
-	rm -rf .build
+	rm -rf .build .swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,10 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(name: "Pomodoro", dependencies: ["ArgumentParser", "SwiftToolsSupport"]),
+        .target(name: "Pomodoro", dependencies: [
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+        ]),
         .target(name: "PomodoroCLI", dependencies: ["Pomodoro"]),
         .testTarget(name: "PomodoroTests", dependencies: ["Pomodoro"]),
     ]


### PR DESCRIPTION
This [previous PR](https://github.com/dirtyhenry/pomodoro-cli/pull/10) brought a regression to the project: after running the binary as installed by `make deploy`, I would get the following error:

```
dyld: Library not loaded: @rpath/libSwiftToolsSupport.dylib
Referenced from: /usr/local/bin/pomodoro-cli
Reason: image not found
```

[A post](https://developer.apple.com/forums/thread/655937) from Apple's developer forum gave me the solution.