### PR TITLE
Add short version of flags

### DIFF
--- a/Sources/Pomodoro/TimeIntervalExtension.swift
+++ b/Sources/Pomodoro/TimeIntervalExtension.swift
@@ -5,7 +5,7 @@ enum TimeIntervalConversionError: Error {
     case unsupportedFormat
 }
 
-extension TimeInterval {
+public extension TimeInterval {
     // MARK: - Creating a time internal from a human readable expression.
 
     /// Interprets a duration from a human readable string.
@@ -14,7 +14,7 @@ extension TimeInterval {
     ///
     /// * A string **with digits only** will be parsed as a number of **seconds** (example: `123`);
     /// * A string **finishing with `m`** will be parsed as a number of **minutes** (example: `123m` or `123 m`).
-    public static func fromHumanReadableString(_ string: String) throws -> TimeInterval {
+    static func fromHumanReadableString(_ string: String) throws -> TimeInterval {
         let normalizedInput = string.replacingOccurrences(of: " ", with: "")
 
         guard let lastChar = normalizedInput.last else {

--- a/Sources/PomodoroCLI/main.swift
+++ b/Sources/PomodoroCLI/main.swift
@@ -4,10 +4,10 @@ import Pomodoro
 import TSCBasic
 
 struct PomodoroCLI: ParsableCommand {
-    @Option(help: "The duration of the pomodoro in seconds (100) or in minutes (10m)")
+    @Option(name: .shortAndLong, help: "The duration of the pomodoro in seconds (100) or in minutes (10m)")
     var duration: String = "25m"
 
-    @Option(help: "The intent of the pomodoro (example: email zero)")
+    @Option(name: .shortAndLong, help: "The intent of the pomodoro (example: email zero)")
     var message: String?
 
     func run() throws {


### PR DESCRIPTION
New help:

```
USAGE: pomodoro-cli [--duration <duration>] [--message <message>]

OPTIONS:
  -d, --duration <duration>
                          The duration of the pomodoro in seconds (100) or in minutes (10m) (default: 25m)
  -m, --message <message> The intent of the pomodoro (example: email zero)
  -h, --help              Show help information.
```

- feat: 🎸 Accept short version of arguments
- style: 💄 Apply linting
