### PR TITLE
2024 Maintenance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2023 Mickaël Floc'hlay
+Copyright (c) 2017-2024 Mickaël Floc'hlay
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # 📜 https://forums.swift.org/t/how-to-distribute-a-swiftpm-executable-on-macos/47127/5
 # 📜 https://developer.apple.com/developer-id/
 
-VERSION = 1.1.0
+VERSION = 1.2.0
 PRODUCT = pomodoro-cli
 
 BINARY = .build/apple/Products/Release/${PRODUCT}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,26 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-          "version": "1.2.2"
-        }
-      },
-      {
-        "package": "swift-system",
-        "repositoryURL": "https://github.com/apple/swift-system.git",
-        "state": {
-          "branch": null,
-          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "swift-tools-support-core",
-        "repositoryURL": "https://github.com/apple/swift-tools-support-core",
-        "state": {
-          "branch": null,
-          "revision": "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
-          "version": "0.5.2"
+          "revision": "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+          "version": "1.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,19 +5,17 @@ import PackageDescription
 let package = Package(
     name: "Pomodoro",
     platforms: [
-        .macOS(.v10_12),
+        .macOS(.v10_13),
     ],
     products: [
         .executable(name: "pomodoro-cli", targets: ["PomodoroCLI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
-        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.2.7")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4")
     ],
     targets: [
         .target(name: "Pomodoro", dependencies: [
-            .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core")
+            .product(name: "ArgumentParser", package: "swift-argument-parser")
         ]),
         .executableTarget(name: "PomodoroCLI", dependencies: ["Pomodoro"]),
         .testTarget(name: "PomodoroTests", dependencies: ["Pomodoro"]),

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Options:
 
 ## Hooks
 
-Pomodoro can optionnaly run shell scripts when a pomodoro starts and/or finishes.
+Pomodoro can optionally run shell scripts when a pomodoro starts and/or finishes.
 
 Sample scripts can be found in [the `SampleHooks` directory](https://github.com/dirtyhenry/pomodoro-cli/blob/main/Resources/SampleHooks).
 

--- a/Sources/Pomodoro/Environment.swift
+++ b/Sources/Pomodoro/Environment.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Environment {
+enum Environment {
     static let dotDirectoryName = ".pomodoro-cli"
 
     static let dotDirectory = FileManager.default

--- a/Sources/PomodoroCLI/main.swift
+++ b/Sources/PomodoroCLI/main.swift
@@ -1,7 +1,37 @@
 import ArgumentParser
 import Foundation
 import Pomodoro
-import TSCBasic
+
+/// Terminal color choices.
+public enum TerminalColor {
+    case noColor
+
+    case red
+    case green
+    case yellow
+    case cyan
+
+    case white
+    case black
+    case gray
+
+    /// Returns the color code which can be prefixed on a string to display it in that color.
+    fileprivate var string: String {
+        switch self {
+            case .noColor: return ""
+            case .red: return "\u{001B}[31m"
+            case .green: return "\u{001B}[32m"
+            case .yellow: return "\u{001B}[33m"
+            case .cyan: return "\u{001B}[36m"
+            case .white: return "\u{001B}[37m"
+            case .black: return "\u{001B}[30m"
+            case .gray: return "\u{001B}[30;1m"
+        }
+    }
+}
+
+/// Code to end any currently active wrapping.
+private let resetString = "\u{001B}[0m"
 
 struct PomodoroCLI: ParsableCommand {
     @Option(name: .shortAndLong, help: "The duration of the pomodoro in seconds (100) or in minutes (10m)")
@@ -12,13 +42,13 @@ struct PomodoroCLI: ParsableCommand {
 
     func run() throws {
         do {
-            var pomodoroMessage: String? = message
+            let pomodoroMessage: String
 
-            if pomodoroMessage == nil {
-                let terminalController = TerminalController(stream: stdoutStream)
-                terminalController?.write("💁‍♀️ What is the intent of this pomodoro?", inColor: .green)
-                terminalController?.endLine()
-                pomodoroMessage = readLine()
+            if let message = self.message {
+                pomodoroMessage = message
+            } else {
+                print("\(TerminalColor.green.string)💁‍♀️ What is the intent of this pomodoro?\(resetString)")
+                pomodoroMessage = readLine() ?? ""
             }
 
             let durationAsTimeInterval = try TimeInterval.fromHumanReadableString(duration)


### PR DESCRIPTION
Since `swift-tools-support-core` was deprecated, this maintenance PR gets rid of this dependency.

The rest is just bump, format, update docs.
